### PR TITLE
chore: generate SBOMs using syft v0.60.1 to enable node binary analysis

### DIFF
--- a/.yardstick.yaml
+++ b/.yardstick.yaml
@@ -60,6 +60,6 @@ result-sets:
 
         - name: syft
           # note: we want to use a fixed version of syft for capturing all results (NOT "latest")
-          version: v0.54.0
+          version: v0.60.1
           # once we have results captured, don't re-capture them
           refresh: false


### PR DESCRIPTION
We need to bump the version of syft in order to enable analysis of node binaries within the quality pipeline going forward