### PR TITLE
bump to yardstick v0.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/anchore/yardstick@v0.4.2
+git+https://github.com/anchore/yardstick@v0.4.3
 # ../yardstick
 click


### PR DESCRIPTION
Fixes tool name split bug, enabling referencing tools with `@` in the version