### PR TITLE
Pin syft to v0.74.1

### DIFF
--- a/.yardstick.yaml
+++ b/.yardstick.yaml
@@ -85,7 +85,9 @@ result-sets:
       tools:
 
         - name: syft
-          # note: if there is ever a problem with the syft version, it can be pinned explicitly here (instead of "latest")
-          version: latest
+          # try not to bump this syft version unless you really need to. The consequence of bumping this version 
+          # is that other repos (such as the grype test/quality gate and vunnel tests/quality gate) will not 
+          # be able to leverage the cache without matching the specific syft version referenced here.
+          version: v0.74.1
           # once we have results captured, don't re-capture them
           refresh: false


### PR DESCRIPTION
We should continue to pin the syft version in order for consumers to predictably use the cache within yardstick configurations. Drift in this version causes cache misses, which are costly since that means that all SBOMs need to be rebuilt. (This is going back on #53 )