### PR TITLE
chore: bump syft to v0.86.1 in the yardstick pipeline

### DIFF
--- a/.github/workflows/update-sboms.yaml
+++ b/.github/workflows/update-sboms.yaml
@@ -12,7 +12,7 @@ jobs:
 
   Publish-SBOMS:
     name: "Publish SBOMs"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04-4core-16gb
     # set the permissions granted to the github token to publish to ghcr.io
     permissions:
       contents: read
@@ -36,5 +36,3 @@ jobs:
 
     - name: Update and publish SBOMs
       run: make update-and-publish-sboms
-
-

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   Checks:
     name: "Checks"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04-4core-16gb
     steps:
     - uses: actions/checkout@v2
 

--- a/.yardstick.yaml
+++ b/.yardstick.yaml
@@ -116,6 +116,6 @@ result-sets:
           # try not to bump this syft version unless you really need to. The consequence of bumping this version
           # is that other repos (such as the grype test/quality gate and vunnel tests/quality gate) will not
           # be able to leverage the cache without matching the specific syft version referenced here.
-          version: v0.74.1
+          version: v0.86.1
           # once we have results captured, don't re-capture them
           refresh: false


### PR DESCRIPTION
This ensures the embedded CPE dictionary enhancements will be taken into account in future quality gate runs. This also swaps out the runner used for validations and the update-sboms workflow to a large runner for more SSD resources.