### PR TITLE
chore: update runner disk space for validations

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -14,6 +14,15 @@ jobs:
     name: "Checks"
     runs-on: ubuntu-20.04
     steps:
+    - name: Maximize runner disk space
+      run: |
+        # Removes .NET runtime and libraries. (frees ~17 GB)
+        sudo rm -rf /usr/share/dotnet
+        # Removes Android SDKs and Tools. (frees ~11 GB)
+        sudo rm -rf /usr/local/lib/android
+        # Removes GHC (Haskell) artifacts. (frees ~2.7 GB)
+        sudo rm -rf /opt/ghc
+
     - uses: actions/checkout@v2
 
     - name: Setup Python


### PR DESCRIPTION
### Summary

Some workflows on PR/main are running into an issue where our validations step is causing the runner to run out of disk. While we look for other ways to optimize the space used, this PR will increase the available space:

https://github.com/easimon/maximize-build-space