### PR TITLE
Upgrade github runner for more disk space

### DIFF
--- a/.github/workflows/update-sboms.yaml
+++ b/.github/workflows/update-sboms.yaml
@@ -12,7 +12,7 @@ jobs:
 
   Publish-SBOMS:
     name: "Publish SBOMs"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-4cores-16gb
     # set the permissions granted to the github token to publish to ghcr.io
     permissions:
       contents: read
@@ -36,5 +36,3 @@ jobs:
 
     - name: Update and publish SBOMs
       run: make update-and-publish-sboms
-
-

--- a/.github/workflows/update-sboms.yaml
+++ b/.github/workflows/update-sboms.yaml
@@ -12,7 +12,7 @@ jobs:
 
   Publish-SBOMS:
     name: "Publish SBOMs"
-    runs-on: ubuntu-20.04-4core
+    runs-on: ubuntu-20.04-4core-16gb
     # set the permissions granted to the github token to publish to ghcr.io
     permissions:
       contents: read

--- a/.github/workflows/update-sboms.yaml
+++ b/.github/workflows/update-sboms.yaml
@@ -12,7 +12,7 @@ jobs:
 
   Publish-SBOMS:
     name: "Publish SBOMs"
-    runs-on: ubuntu-20.04-4cores-16gb
+    runs-on: ubuntu-20.04-4core
     # set the permissions granted to the github token to publish to ghcr.io
     permissions:
       contents: read

--- a/.github/workflows/update-sboms.yaml
+++ b/.github/workflows/update-sboms.yaml
@@ -12,7 +12,7 @@ jobs:
 
   Publish-SBOMS:
     name: "Publish SBOMs"
-    runs-on: ubuntu-20.04-4core-16gb
+    runs-on: ubuntu-22.04-4core-16gb
     # set the permissions granted to the github token to publish to ghcr.io
     permissions:
       contents: read


### PR DESCRIPTION
We're starting to run out of disk space when doing analyses with all configured images. We could go the route of deleting files or upgrade the runner resources (which seems more kosher).