### PR TITLE
chore: bump sboms to syft v0.89.0

### DIFF
--- a/.yardstick.yaml
+++ b/.yardstick.yaml
@@ -116,6 +116,6 @@ result-sets:
           # try not to bump this syft version unless you really need to. The consequence of bumping this version
           # is that other repos (such as the grype test/quality gate and vunnel tests/quality gate) will not
           # be able to leverage the cache without matching the specific syft version referenced here.
-          version: v0.87.1
+          version: v0.89.0
           # once we have results captured, don't re-capture them
           refresh: false


### PR DESCRIPTION
Bumps the sboms in the quality gate cache to syft v0.89.0 to take advantage of further improvements to PURL-generation logic for java packages